### PR TITLE
Initialized examples submodule and locked typescript loader to 2.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "examples/book"]
+	path = examples/book
+	url = https://github.com/graforlock/sodium-typescript-examples

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/source-map": "^0.1.26",
     "@types/uglify-js": "^2.0.27",
     "@types/webpack": "^1.12.30",
-    "awesome-typescript-loader": "^2.0.1",
+    "awesome-typescript-loader": "2.0.1",
     "jasmine-core": "^2.4.1",
     "karma": "^1.1.2",
     "karma-jasmine": "^1.0.2",


### PR DESCRIPTION
- Included initial (but working) examples from ```https://github.com/graforlock/sodium-typescript-examples```. I left it as submodule for convenience, there are some branches that are in progress.
- Fixed the build, as previously I did not hardcode ```awesome-typescript-loader``` version to ```2.0.1```.