### PR TITLE
Issue 61

### DIFF
--- a/src/lib/sodium/Vertex.ts
+++ b/src/lib/sodium/Vertex.ts
@@ -59,6 +59,7 @@ export function describeAll(v : Vertex, visited : Set<number>)
 
 export class Vertex {
     static NULL : Vertex = new Vertex("user", 1e12, []);
+    static collectingCycles : boolean = false;
     id : number;
 
 	constructor(name : string, rank : number, sources : Source[]) {
@@ -101,7 +102,7 @@ export class Vertex {
         if (verbose)
             console.log("DEC "+this.descr());
         let matched = false;
-        for (let i = 0; i < target.childrn.length; i++)
+        for (let i = target.childrn.length-1; i >= 0; i--)
             if (target.childrn[i] === this) {
                 target.childrn.splice(i, 1);
             }
@@ -199,9 +200,17 @@ export class Vertex {
 	}
 
 	static collectCycles() : void {
-	    Vertex.markRoots();
-	    Vertex.scanRoots();
-	    Vertex.collectRoots();
+        if (Vertex.collectingCycles) {
+            return;
+        }
+        try {
+            Vertex.collectingCycles = true;
+            Vertex.markRoots();
+            Vertex.scanRoots();
+            Vertex.collectRoots();
+        } finally {
+            Vertex.collectingCycles = false;
+        }
 	}
 
 	static markRoots() : void {

--- a/src/tests/unit/InnerLoop.spec.ts
+++ b/src/tests/unit/InnerLoop.spec.ts
@@ -10,10 +10,12 @@ import {
     Cell,
     CellLoop,
     getTotalRegistrations,
-    lambda2
+    lambda2,
+    Vertex
 } from '../../lib/Lib';
 
 afterEach(() => {
+    Vertex.collectCycles();
     if (getTotalRegistrations() != 0) {
         throw new Error('listeners were not deregistered');
     }
@@ -73,7 +75,7 @@ test('example 2: with loop', (done) => {
         const ccUpdate =
             sAdd.orElse(sRemoveAll)
                 .snapshot(ccLoop, lambda2(
-                    (str, xs) => str === "" ? emptyCell : makeItem(str),
+                    (str, xs) => Cell.switchC(xs.map((unused) => str === "" ? emptyCell : makeItem(str))),
                     [emptyCell, sModify])
                 )
                 .hold(emptyCell);

--- a/src/tests/unit/InnerLoop.spec.ts
+++ b/src/tests/unit/InnerLoop.spec.ts
@@ -10,12 +10,10 @@ import {
     Cell,
     CellLoop,
     getTotalRegistrations,
-    lambda2,
-    Vertex
+    lambda2
 } from '../../lib/Lib';
 
 afterEach(() => {
-    Vertex.collectCycles();
     if (getTotalRegistrations() != 0) {
         throw new Error('listeners were not deregistered');
     }


### PR DESCRIPTION
Solution to issue #61.
To be reviewed.

I also had to make sure ```xs``` gets used in.

```
        const ccUpdate =
            sAdd.orElse(sRemoveAll)
                .snapshot(ccLoop, lambda2(
                    (str, xs) => Cell.switchC(xs.map((unused) => str === "" ? emptyCell : makeItem(str))),
                    [emptyCell, sModify])
                )
                .hold(emptyCell);
```

so that it eventually gets listened to. This is done via a dummy switch-map ```switchC(map((unused) =>...``` to connect the dependency.