### PR TITLE
insured decRefCount is the exact opposite of incRefCount

### DIFF
--- a/src/lib/sodium/Vertex.ts
+++ b/src/lib/sodium/Vertex.ts
@@ -106,6 +106,7 @@ export class Vertex {
         for (let i = target.childrn.length-1; i >= 0; i--)
             if (target.childrn[i] === this) {
                 target.childrn.splice(i, 1);
+                break;
             }
         for (let i = 0; i < this.targets.length; i++)
             if (this.targets[i] === target) {


### PR DESCRIPTION
calling incRefCount with the same target twice, then calling decRefCount once on the same target was not restoring the state of the vertex back to the state it was after calling incRefCount just once.

In other words decRefCount is not the exact opposite of incRefCount.

incRefCount was allowing the addition of the same child multiple times, but decRecCount was removing all of the same child and not just one of the same.

This can cause some sodium objects to be unregistered too soon leading to weird behaviour.