### PR TITLE
memory management fixes for #61

### DIFF
--- a/src/lib/sodium/Vertex.ts
+++ b/src/lib/sodium/Vertex.ts
@@ -223,7 +223,7 @@ export class Vertex {
 	static markRoots() : void {
         const newRoots : Vertex[] = [];
         // check refCountAdj was restored to zero before mark roots
-        if (verbose || true) {
+        if (verbose) {
             let stack: Vertex[] = roots.slice(0);
             let visited: Set<number> = new Set();
             while (stack.length != 0) {
@@ -268,7 +268,7 @@ export class Vertex {
 	        roots[i].buffered = false;
 	        roots[i].collectWhite();
         }
-        if (verbose || true) { // double check adjRefCount is zero for all vertices reachable by roots
+        if (verbose) { // double check adjRefCount is zero for all vertices reachable by roots
             let stack: Vertex[] = roots.slice(0);
             let visited: Set<number> = new Set();
             while (stack.length != 0) {

--- a/src/lib/sodium/Vertex.ts
+++ b/src/lib/sodium/Vertex.ts
@@ -61,6 +61,7 @@ export function describeAll(v : Vertex, visited : Set<number>)
 export class Vertex {
     static NULL : Vertex = new Vertex("user", 1e12, []);
     static collectingCycles : boolean = false;
+    static toBeFreedList : Vertex[] = [];
     id : number;
 
 	constructor(name : string, rank : number, sources : Source[]) {
@@ -210,13 +211,37 @@ export class Vertex {
             Vertex.markRoots();
             Vertex.scanRoots();
             Vertex.collectRoots();
+            for (let i = Vertex.toBeFreedList.length-1; i >= 0; --i) {
+                let vertex = Vertex.toBeFreedList.splice(i, 1)[0];
+                vertex.free();
+            }
         } finally {
             Vertex.collectingCycles = false;
         }
 	}
 
 	static markRoots() : void {
-	    const newRoots : Vertex[] = [];
+        const newRoots : Vertex[] = [];
+        // check refCountAdj was restored to zero before mark roots
+        if (verbose || true) {
+            let stack: Vertex[] = roots.slice(0);
+            let visited: Set<number> = new Set();
+            while (stack.length != 0) {
+                let vertex = stack.pop();
+                if (visited.contains(vertex.id)) {
+                    continue;
+                }
+                visited.add(vertex.id);
+                if (vertex.refCountAdj != 0) {
+                    console.log("markRoots(): reachable refCountAdj was not reset to zero: " + vertex.descr());
+                }
+                for (let i = 0; i < vertex.childrn.length; ++i) {
+                    let child = vertex.childrn[i];
+                    stack.push(child);
+                }
+            }
+        }
+        //
 	    for (let i = 0; i < roots.length; i++) {
             if (verbose)
                 console.log("markRoots "+roots[i].descr());  // ###
@@ -226,8 +251,8 @@ export class Vertex {
             }
 	        else {
 	            roots[i].buffered = false;
-	            if (roots[i].color == Color.black && roots[i].refCount() == 0)
-	                roots[i].free();
+                if (roots[i].color == Color.black && roots[i].refCount() == 0)
+	                Vertex.toBeFreedList.push(roots[i]);
             }
 	    }
 	    roots = newRoots;
@@ -242,7 +267,25 @@ export class Vertex {
 	    for (let i = 0; i < roots.length; i++) {
 	        roots[i].buffered = false;
 	        roots[i].collectWhite();
-	    }
+        }
+        if (verbose || true) { // double check adjRefCount is zero for all vertices reachable by roots
+            let stack: Vertex[] = roots.slice(0);
+            let visited: Set<number> = new Set();
+            while (stack.length != 0) {
+                let vertex = stack.pop();
+                if (visited.contains(vertex.id)) {
+                    continue;
+                }
+                visited.add(vertex.id);
+                if (vertex.refCountAdj != 0) {
+                    console.log("collectRoots(): reachable refCountAdj was not reset to zero: " + vertex.descr());
+                }
+                for (let i = 0; i < vertex.childrn.length; ++i) {
+                    let child = vertex.childrn[i];
+                    stack.push(child);
+                }
+            }
+        }
 	    roots = [];
 	}
 
@@ -277,10 +320,10 @@ export class Vertex {
 	}
 
 	scanBlack() : void {
+        this.refCountAdj = 0;
 	    this.color = Color.black;
         let chs = this.children();
         for (let i = 0; i < chs.length; i++) {
-            chs[i].refCountAdj++;
             if (verbose)
                 console.log("scanBlack "+this.descr());
             if (chs[i].color != Color.black)
@@ -297,7 +340,7 @@ export class Vertex {
             let chs = this.children();
             for (let i = 0; i < chs.length; i++)
                 chs[i].collectWhite();
-            this.free();
+            Vertex.toBeFreedList.push(this);
 	    }
 	}
 }


### PR DESCRIPTION
memory management fixes for #61.

- A Vertex.toBeFreedList is used to defer freeing vertices until the very end to stop missing some children when iterating through the children array (keeps children array fixed until the very end, then it may change).

- scanBlack() was resetting all refCountAdj except the very 1st vertex it started at. The very 1st vertex is now included in the reset, and refCountAdj is no longer negative when finished and before beginning collect cycles.

- Additional debug output added for when Vertex.verbose is set to true to insure the negative refCountAdj is not happening when collect cycles is finished or before collect cycles begins. 