### PR TITLE
split / defer rank fix

### DIFF
--- a/src/lib/sodium/Operational.ts
+++ b/src/lib/sodium/Operational.ts
@@ -82,7 +82,7 @@ export class Operational {
                 new Source(
                     s.getVertex__(),
                     () => {
-                        return s.listen_(out.getVertex__(), (as : Array<A>) => {
+                        return s.listen_(Vertex.NULL, (as : Array<A>) => {
                             for (let i = 0; i < as.length; i++) {
                                 Transaction.currentTransaction.post(i, () => {
                                     Transaction.run(() => {

--- a/src/lib/sodium/Vertex.ts
+++ b/src/lib/sodium/Vertex.ts
@@ -151,9 +151,7 @@ export class Vertex {
 
 	private ensureBiggerThan(limit : number) : boolean {
         if (this.visited) {
-            // Timer.spec.ts has a vertex cycle, this should be fixed first.
-            //throw new Error("Vertex cycle detected.");
-            return false;
+            throw new Error("Vertex cycle detected.");
         }
 		if (this.rank > limit)
 			return false;

--- a/src/lib/sodium/Vertex.ts
+++ b/src/lib/sodium/Vertex.ts
@@ -151,7 +151,9 @@ export class Vertex {
 
 	private ensureBiggerThan(limit : number) : boolean {
         if (this.visited) {
-            throw new Error("Vertex cycle detected.");
+            // Undoing cycle detection for now until TimerSystem.ts ranks are checked.
+            //throw new Error("Vertex cycle detected.");
+            return false;
         }
 		if (this.rank > limit)
 			return false;

--- a/src/tests/unit/StreamSink.spec.ts
+++ b/src/tests/unit/StreamSink.spec.ts
@@ -571,3 +571,15 @@ test('should test loopCell', (done) => {
   expect(6).toBe(sum_out.sample());
 });
 
+test('should test defer/split memory cycle', done => {
+  // We do not fire through sl here, as it would cause an infinite loop.
+  // This is just a memory management test.
+  let sl : StreamLoop<number>;
+  Transaction.run(() => {
+    sl = new StreamLoop<number>();
+    sl.loop(Operational.defer(sl));
+  });
+  let kill = sl.listen(() => {});
+  kill();
+  done();
+});

--- a/src/tests/unit/Timer.spec.ts
+++ b/src/tests/unit/Timer.spec.ts
@@ -3,7 +3,6 @@ import {
   Stream,
   StreamSink,
   CellLoop,
-  Operational,
   TimerSystem,
   SecondsTimerSystem,
   Transaction,

--- a/src/tests/unit/Timer.spec.ts
+++ b/src/tests/unit/Timer.spec.ts
@@ -19,7 +19,7 @@ test('should test Timer', (done) => {
       oAlarm = new CellLoop<number>(),
       sAlarm = sys.at(oAlarm);
     oAlarm.loop(
-      Operational.defer(sAlarm.map(t => t + period))
+      sAlarm.map(t => t + period)
         .hold(time.sample() + period));
     return sAlarm;
   }

--- a/src/tests/unit/Timer.spec.ts
+++ b/src/tests/unit/Timer.spec.ts
@@ -3,6 +3,7 @@ import {
   Stream,
   StreamSink,
   CellLoop,
+  Operational,
   TimerSystem,
   SecondsTimerSystem,
   Transaction,
@@ -18,7 +19,7 @@ test('should test Timer', (done) => {
       oAlarm = new CellLoop<number>(),
       sAlarm = sys.at(oAlarm);
     oAlarm.loop(
-      sAlarm.map(t => t + period)
+      Operational.defer(sAlarm.map(t => t + period))
         .hold(time.sample() + period));
     return sAlarm;
   }


### PR DESCRIPTION
Just double check this first. I'm pretty sure that in Operational::split, Vertex.NULL should be used as the target instead of out.getVertex__() in order to break the rank dependency as the values get fired in a transaction after the current transaction (not rank dependent) and before any new transactions are created.