### PR TITLE
children and targets as multiset

### DIFF
--- a/src/lib/sodium/Vertex.ts
+++ b/src/lib/sodium/Vertex.ts
@@ -278,12 +278,7 @@ export class Vertex {
     }
 
     free() : void {
-        let targets: Vertex[] = [];
-        this.targets.forEach((target, count) => {
-            for (let i = 0; i < count; ++i) {
-                targets.push(target);
-            }
-        });
+        let targets: Vertex[] = this.targetArray().slice(0);
         for (let i = 0; i < targets.length; ++i) {
             this.decRefCount(targets[i]);
         }


### PR DESCRIPTION
Relates to: #93 

Little performance improvement for cases where vertices have a large number of targets or a large number of children. (Including the case of Cell::setStream_() when it uses Vertex.NULL).

The performance improvement can only be noticed in a changing FRP graph, not a static one.

Not sure if this should be merged. It is making the implementation a little more complicated. And I need to run some more tests to see if the performance gain (or loss) is worth it.

This PR also conflicts with the #94 PR. They can not be merged both together yet.