### PR TITLE
fixed tracking

### DIFF
--- a/src/lib/sodium/Cell.ts
+++ b/src/lib/sodium/Cell.ts
@@ -254,30 +254,61 @@ export class Cell<A> {
      * happen to accumulate state, this method will keep the accumulation of state up to date.
      */
     public tracking(extractor: (a: A) => (Stream<any>|Cell<any>)[]) : Cell<A> {
-        let cKeepAlive = Cell.switchC(this.map(
-            a =>
-                Cell.liftArray(
-                    extractor(a).map(
-                        x => {
-                            if (x instanceof Stream) {
-                                return x.hold({} as any);
-                            } else {
-                                return x;
+        const out = new StreamWithSend<A>(null);
+        let vertex = new Vertex("tracking", 0, [
+            new Source(
+                this.vertex,
+                () => {
+                    let cleanup2: ()=>void = () => {};
+                    let updateDeps =
+                        (a: A) => {
+                            let lastCleanups2 = cleanup2;
+                            let deps = extractor(a).map(dep => dep.getVertex__());
+                            for (let i = 0; i < deps.length; ++i) {
+                                let dep = deps[i];
+                                vertex.childrn.push(dep);
+                                dep.increment(Vertex.NULL);
                             }
-                        }
-                    )
-                )
-        ));
-        return this.map(lambda1(a => a, [cKeepAlive]));
+                            cleanup2 = () => {
+                                for (let i = 0; i < deps.length; ++i) {
+                                    let dep = deps[i];
+                                    for (let j = 0; j < vertex.childrn.length; ++j) {
+                                        if (vertex.childrn[j] === dep) {
+                                            vertex.childrn.splice(j, 1);
+                                            break;
+                                        }
+                                    }
+                                    dep.decrement(Vertex.NULL);
+                                }
+                            };
+                            lastCleanups2();
+                        };
+                    updateDeps(this.sample());
+                    var cleanup1 =
+                        Operational.updates(this).listen_(
+                            vertex,
+                            (a: A) => {
+                                updateDeps(a);
+                                out.send_(a);
+                            },
+                            false
+                        );
+                    return () => {
+                        cleanup1();
+                        cleanup2();
+                    }
+                }
+            )
+        ]);
+        out.setVertex__(vertex);
+        return out.holdLazy(this.sampleLazy());
     }
 
     /**
      * Lift an array of cells into a cell of an array.
      */
     public static liftArray<A>(ca : Cell<A>[]) : Cell<A[]> {
-        // HACK: The ".map(lambda1(x => x, ca))" is required for Cell::tracking to work at the moment.
-        // I'm not sure why it is needed, but it makes it work. More investigation will need to be done later.
-        return Cell._liftArray(ca, 0, ca.length).map(lambda1(x => x, ca));
+        return Cell._liftArray(ca, 0, ca.length);
     }
 
     private static _liftArray<A>(ca : Cell<A>[], fromInc: number, toExc: number) : Cell<A[]> {

--- a/src/lib/sodium/Cell.ts
+++ b/src/lib/sodium/Cell.ts
@@ -275,7 +275,9 @@ export class Cell<A> {
      * Lift an array of cells into a cell of an array.
      */
     public static liftArray<A>(ca : Cell<A>[]) : Cell<A[]> {
-        return Cell._liftArray(ca, 0, ca.length);
+        // HACK: The ".map(lambda1(x => x, ca))" is required for Cell::tracking to work at the moment.
+        // I'm not sure why it is needed, but it makes it work. More investigation will need to be done later.
+        return Cell._liftArray(ca, 0, ca.length).map(lambda1(x => x, ca));
     }
 
     private static _liftArray<A>(ca : Cell<A>[], fromInc: number, toExc: number) : Cell<A[]> {


### PR DESCRIPTION
Cell.tracking was sometimes not working unless ```.map(lambda1(x => x, ca))``` is added to ```Cell::liftArray```. I do not know why that is the case, more investigation will need to be done later.

Cell::tracking should probably be re-implemented using ```Vertex``` to save on some performance cost of grouping all tracking values into an array that never gets seen.